### PR TITLE
More docs errors fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Example:
 ```
 
 Will move the first alien in the list to the center of the map
+
 Accepted options when using alien.set:
 
 |option|value|
@@ -177,6 +178,7 @@ Accepted options when using alien.set:
 
 # Ships
 You can access to the list of ships (players) through the array game.ships
+
 You have read access to the ship’s main fields and options:
 
 |field|value|
@@ -207,6 +209,7 @@ Example:
 ```
 
 Will move the first ship in the list to the center of the map
+
 Accepted options when using ship.set:
 
 |option|value|


### PR DESCRIPTION
Errors fixed: alien.set, ship.set, & ship read-only options (two sentences appeared on the same line without periods separating them for all three mentioned errors). Sorry to bother you @pmgl.